### PR TITLE
Going back to source.blade

### DIFF
--- a/Laravel Blade.sublime-syntax
+++ b/Laravel Blade.sublime-syntax
@@ -4,7 +4,7 @@ name: Laravel Blade
 file_extensions:
   - blade
   - blade.php
-scope: text.blade
+scope: source.blade
 
 contexts:
   main:

--- a/Snippets/blade-choice.sublime-snippet
+++ b/Snippets/blade-choice.sublime-snippet
@@ -5,5 +5,5 @@
     <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
     <tabTrigger>blchoice</tabTrigger>
     <!-- Optional: Set a scope to limit where the snippet will trigger -->
-    <scope>text.blade</scope>
+    <scope>source.blade</scope>
 </snippet>

--- a/Snippets/blade-comments.sublime-snippet
+++ b/Snippets/blade-comments.sublime-snippet
@@ -5,5 +5,5 @@
     <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
     <tabTrigger>blcomment</tabTrigger>
     <!-- Optional: Set a scope to limit where the snippet will trigger -->
-    <scope>text.blade</scope>
+    <scope>source.blade</scope>
 </snippet>

--- a/Snippets/blade-each.sublime-snippet
+++ b/Snippets/blade-each.sublime-snippet
@@ -5,5 +5,5 @@
     <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
     <tabTrigger>bleach</tabTrigger>
     <!-- Optional: Set a scope to limit where the snippet will trigger -->
-    <scope>text.blade</scope>
+    <scope>source.blade</scope>
 </snippet>

--- a/Snippets/blade-echo-unescaped.sublime-snippet
+++ b/Snippets/blade-echo-unescaped.sublime-snippet
@@ -5,5 +5,5 @@
     <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
     <tabTrigger>blecho!</tabTrigger>
     <!-- Optional: Set a scope to limit where the snippet will trigger -->
-    <scope>text.blade</scope>
+    <scope>source.blade</scope>
 </snippet>

--- a/Snippets/blade-echo.sublime-snippet
+++ b/Snippets/blade-echo.sublime-snippet
@@ -5,5 +5,5 @@
     <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
     <tabTrigger>blecho</tabTrigger>
     <!-- Optional: Set a scope to limit where the snippet will trigger -->
-    <scope>text.blade</scope>
+    <scope>source.blade</scope>
 </snippet>

--- a/Snippets/blade-extends.sublime-snippet
+++ b/Snippets/blade-extends.sublime-snippet
@@ -5,5 +5,5 @@
     <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
     <tabTrigger>blext</tabTrigger>
     <!-- Optional: Set a scope to limit where the snippet will trigger -->
-    <scope>text.blade</scope>
+    <scope>source.blade</scope>
 </snippet>

--- a/Snippets/blade-for.sublime-snippet
+++ b/Snippets/blade-for.sublime-snippet
@@ -7,5 +7,5 @@
     <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
     <tabTrigger>blfor</tabTrigger>
     <!-- Optional: Set a scope to limit where the snippet will trigger -->
-    <scope>text.blade</scope>
+    <scope>source.blade</scope>
 </snippet>

--- a/Snippets/blade-foreach.sublime-snippet
+++ b/Snippets/blade-foreach.sublime-snippet
@@ -7,5 +7,5 @@ $4
     <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
     <tabTrigger>blforeach</tabTrigger>
     <!-- Optional: Set a scope to limit where the snippet will trigger -->
-    <scope>text.blade</scope>
+    <scope>source.blade</scope>
 </snippet>

--- a/Snippets/blade-forelse.sublime-snippet
+++ b/Snippets/blade-forelse.sublime-snippet
@@ -9,5 +9,5 @@ ${4:@empty
     <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
     <tabTrigger>blforelse</tabTrigger>
     <!-- Optional: Set a scope to limit where the snippet will trigger -->
-    <scope>text.blade</scope>
+    <scope>source.blade</scope>
 </snippet>

--- a/Snippets/blade-if.sublime-snippet
+++ b/Snippets/blade-if.sublime-snippet
@@ -11,5 +11,5 @@ ${3:@elseif (${4:condition})
     <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
     <tabTrigger>blif</tabTrigger>
     <!-- Optional: Set a scope to limit where the snippet will trigger -->
-    <scope>text.blade</scope>
+    <scope>source.blade</scope>
 </snippet>

--- a/Snippets/blade-includes.sublime-snippet
+++ b/Snippets/blade-includes.sublime-snippet
@@ -5,5 +5,5 @@
     <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
     <tabTrigger>blinclude</tabTrigger>
     <!-- Optional: Set a scope to limit where the snippet will trigger -->
-    <scope>text.blade</scope>
+    <scope>source.blade</scope>
 </snippet>

--- a/Snippets/blade-lang.sublime-snippet
+++ b/Snippets/blade-lang.sublime-snippet
@@ -5,5 +5,5 @@
     <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
     <tabTrigger>bllang</tabTrigger>
     <!-- Optional: Set a scope to limit where the snippet will trigger -->
-    <scope>text.blade</scope>
+    <scope>source.blade</scope>
 </snippet>

--- a/Snippets/blade-php-small.sublime-snippet
+++ b/Snippets/blade-php-small.sublime-snippet
@@ -5,5 +5,5 @@
     <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
     <tabTrigger>blphpsm</tabTrigger>
     <!-- Optional: Set a scope to limit where the snippet will trigger -->
-    <scope>text.blade</scope>
+    <scope>source.blade</scope>
 </snippet>

--- a/Snippets/blade-php.sublime-snippet
+++ b/Snippets/blade-php.sublime-snippet
@@ -7,5 +7,5 @@
     <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
     <tabTrigger>blphp</tabTrigger>
     <!-- Optional: Set a scope to limit where the snippet will trigger -->
-    <scope>text.blade</scope>
+    <scope>source.blade</scope>
 </snippet>

--- a/Snippets/blade-section-small.sublime-snippet
+++ b/Snippets/blade-section-small.sublime-snippet
@@ -5,5 +5,5 @@
     <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
     <tabTrigger>blsectionsm</tabTrigger>
     <!-- Optional: Set a scope to limit where the snippet will trigger -->
-    <scope>text.blade</scope>
+    <scope>source.blade</scope>
 </snippet>

--- a/Snippets/blade-section.sublime-snippet
+++ b/Snippets/blade-section.sublime-snippet
@@ -7,5 +7,5 @@ $2
     <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
     <tabTrigger>blsection</tabTrigger>
     <!-- Optional: Set a scope to limit where the snippet will trigger -->
-    <scope>text.blade</scope>
+    <scope>source.blade</scope>
 </snippet>

--- a/Snippets/blade-service-injection.sublime-snippet
+++ b/Snippets/blade-service-injection.sublime-snippet
@@ -5,5 +5,5 @@
     <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
     <tabTrigger>blinject</tabTrigger>
     <!-- Optional: Set a scope to limit where the snippet will trigger -->
-    <scope>text.blade</scope>
+    <scope>source.blade</scope>
 </snippet>

--- a/Snippets/blade-unless.sublime-snippet
+++ b/Snippets/blade-unless.sublime-snippet
@@ -7,5 +7,5 @@
     <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
     <tabTrigger>blunless</tabTrigger>
     <!-- Optional: Set a scope to limit where the snippet will trigger -->
-    <scope>text.blade</scope>
+    <scope>source.blade</scope>
 </snippet>

--- a/Snippets/blade-unset.sublime-snippet
+++ b/Snippets/blade-unset.sublime-snippet
@@ -5,5 +5,5 @@
     <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
     <tabTrigger>blunset</tabTrigger>
     <!-- Optional: Set a scope to limit where the snippet will trigger -->
-    <scope>text.blade</scope>
+    <scope>source.blade</scope>
 </snippet>

--- a/Snippets/blade-while.sublime-snippet
+++ b/Snippets/blade-while.sublime-snippet
@@ -7,5 +7,5 @@
     <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
     <tabTrigger>blwhile</tabTrigger>
     <!-- Optional: Set a scope to limit where the snippet will trigger -->
-    <scope>text.blade</scope>
+    <scope>source.blade</scope>
 </snippet>

--- a/Snippets/blade-yield.sublime-snippet
+++ b/Snippets/blade-yield.sublime-snippet
@@ -5,5 +5,5 @@
     <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
     <tabTrigger>blyield</tabTrigger>
     <!-- Optional: Set a scope to limit where the snippet will trigger -->
-    <scope>text.blade</scope>
+    <scope>source.blade</scope>
 </snippet>


### PR DESCRIPTION
This makes the autocomplete popup available for our snippets (and others, actually), since the default config in sublime text is to show said popup in "source code, but not comments", as said [in this commit's comments](https://github.com/jbrooksuk/Sublime-Blade/commit/8c4a131f026a295fe5a48d2c69ec25d1d492c597).

@jbrooksuk  : I'll let you decide if you want to go through with it! ;-)
